### PR TITLE
fix: Stash and pop any unstaged changes before rebasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove last dependency on external git binary, using libgit2 for all git interactions
 * Show backtraces on error if RUST_BACKTRACE=1 is in the environment
+* Correctly stash and unstash changes before the rebase
 
 # Version 0.2.0
 


### PR DESCRIPTION
In this particular case poping is I think guaranteed to be conflict free.